### PR TITLE
fix: integration with Next.js 9.2

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should add condition to Next.js built-in oneOf rule that adds CSS support 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "oneOf": Array [
+          Object {
+            "oneOf": Array [
+              Object {
+                "test": /\\\\\\.module\\\\\\.css\\$/,
+              },
+            ],
+            "test": /\\\\\\.css\\$/,
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
 exports[`should return in .oneOf rules sent in .rules 1`] = `
 Object {
   "module": Object {
@@ -7,7 +28,7 @@ Object {
       Object {
         "oneOf": Array [
           Object {
-            "should": "work",
+            "test": /\\\\\\.js\\$/,
           },
         ],
       },

--- a/index.js
+++ b/index.js
@@ -3,6 +3,19 @@
 module.exports = (nextConfig = {}) => ({
     ...nextConfig,
     webpack(config, options) {
+        // Fix for Next.js >= 9.2, where it introduced a oneOf rules for CSS
+        // When there are nested oneOf rules, Webpack stops at the first occurrence of a `oneOf` rule
+        // because it has no conditions (test, exclude, etc).
+        // We fix that by adding a test condition to the CSS oneOf rule
+        const cssRule = config.module.rules.find((rule) => (
+            rule.oneOf && Object.keys(rule).length === 1) &&
+            rule.oneOf.some((rule) => `${rule.test}`.includes('\\.module\\.css')),
+        );
+
+        if (cssRule) {
+            cssRule.test = /\.css$/;
+        }
+
         config.module.rules = [{
             oneOf: [...config.module.rules],
         }];

--- a/index.test.js
+++ b/index.test.js
@@ -10,22 +10,24 @@ const createConfig = (loaderRules = []) => ({
 
 it('should return in .oneOf rules sent in .rules', () => {
     const rules = [{
-        should: 'work',
+        test: /\.js$/,
     }];
-
-    const createOneOf = (loaderRules = []) => ({
-        module: {
-            rules: [{
-                oneOf:
-                    [...loaderRules],
-            }],
-        },
-    });
 
     const webpackConfig = alwaysOneOf().webpack(createConfig(rules));
 
     expect(webpackConfig).toMatchSnapshot();
-    expect(webpackConfig).toStrictEqual(createOneOf(rules));
+});
+
+it('should add condition to Next.js built-in oneOf rule that adds CSS support', () => {
+    const rules = [{
+        oneOf: [{
+            test: /\.module\.css$/,
+        }],
+    }];
+
+    const webpackConfig = alwaysOneOf().webpack(createConfig(rules));
+
+    expect(webpackConfig).toMatchSnapshot();
 });
 
 it('should call nextConfig webpack if defined', () => {


### PR DESCRIPTION
Fix for Next.js >= 9.2, where it introduced a oneOf rules for CSS
When there are nested oneOf rules, Webpack stops at the first occurrence of a `oneOf` rule because it has no conditions (test, exclude, etc).
We fix that by adding a test condition to the oneOf rule.

I also simplified / improved tests